### PR TITLE
Update hci.h

### DIFF
--- a/include/net/bluetooth/hci.h
+++ b/include/net/bluetooth/hci.h
@@ -342,7 +342,7 @@ enum {
 #define HCI_AUTO_OFF_TIMEOUT	msecs_to_jiffies(2000)	/* 2 seconds */
 #define HCI_POWER_OFF_TIMEOUT	msecs_to_jiffies(5000)	/* 5 seconds */
 #define HCI_LE_CONN_TIMEOUT	msecs_to_jiffies(20000)	/* 20 seconds */
-#define HCI_LE_AUTOCONN_TIMEOUT	msecs_to_jiffies(4000)	/* 4 seconds */
+#define HCI_LE_AUTOCONN_TIMEOUT	msecs_to_jiffies(20000)	/* 20 seconds */
 
 /* HCI data types */
 #define HCI_COMMAND_PKT		0x01


### PR DESCRIPTION
For power optimised BLE slave-devices HCI_LE_AUTOCONN_TIMEOUT needs to be more than 4 seconds, otherwise master cant connect to some slaves. 20 seconds gives slave to sleep longer time and consume less battery.